### PR TITLE
Ab/welcome: Visual spacing change in Onboarding and minor fix to home screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/data/VideoResponse.kt
+++ b/composeApp/src/commonMain/kotlin/data/VideoResponse.kt
@@ -22,7 +22,6 @@ data class Video(
     val pictures: Pictures,
     val privacy: Privacy?,
     val content_rating: List<String>,
-//    val embed: String,
     @SerialName("player_embed_url") val playerEmbedUrl: String
 ) {
     var streamUrl: String? = null

--- a/composeApp/src/commonMain/kotlin/data/VideoStreamResponse.kt
+++ b/composeApp/src/commonMain/kotlin/data/VideoStreamResponse.kt
@@ -9,7 +9,7 @@ data class VideoStreamResponse(val request: Request?)
 data class Request(val files: Files)
 
 @Serializable
-data class Files(val progressive: List<Progressive>)
+data class Files(val progressive: List<Progressive>?)
 
 @Serializable
 data class Progressive(val id: String, val profile: String, val url: String)

--- a/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/home/HomeScreen.kt
@@ -68,7 +68,6 @@ fun HomeScreen(platform: Platform, navigationStack: NavigationStack<Destination>
             }
         }
         item {
-//            Spacer(Modifier.height(16.dp))
             Text("Review all levels", Modifier.padding(16.dp))
         }
         items(curriculum.entries.toList()) { entry ->

--- a/composeApp/src/commonMain/kotlin/presentation/screens/onboarding/OnboardingFlow.kt
+++ b/composeApp/src/commonMain/kotlin/presentation/screens/onboarding/OnboardingFlow.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -79,7 +80,7 @@ fun EnterNameAndRankScreen(platform: Platform, action: () -> Unit) {
         App(platform)
     } else {
         Box(Modifier.fillMaxSize().background(Color.LightGray)) {
-            Column(Modifier.fillMaxSize()) {
+            Column(Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
                 // Name Field
                 OutlinedTextField(
                     value = viewModel.firstName.value,
@@ -96,7 +97,7 @@ fun EnterNameAndRankScreen(platform: Platform, action: () -> Unit) {
 
                 LazyVerticalStaggeredGrid(
                     columns = StaggeredGridCells.Fixed(2),
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
                 ) {
                     items(BeltLevel.entries) {
                         Text(text = it.name, modifier = Modifier.clickable {


### PR DESCRIPTION
Fix spacing in Onboarding screen and make Progressives list nullable as this was breaking some functionality on home screen